### PR TITLE
Fix top left radius on news section

### DIFF
--- a/src/app/landing/landing.component.html
+++ b/src/app/landing/landing.component.html
@@ -118,7 +118,7 @@
           </div>
         </div>
         <div class="col-md-4">
-          <div class="card bg-default shadow border-0">
+          <div class="card card-news bg-default shadow border-0">
             <blockquote class="card-blockquote">
               <svg preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 583 65" class="svg-bg">
                 <polygon points="0,52 383,95 0,95" class="fill-default" />

--- a/src/assets/scss/custom/_card.scss
+++ b/src/assets/scss/custom/_card.scss
@@ -85,6 +85,10 @@
     }
 }
 
+.card-news {
+    border-top-left-radius: 0;
+}
+
 // Animated cards
 
 .card-lift--hover {


### PR DESCRIPTION
Fix top left radius on news section (landing page)

Before:

![image](https://user-images.githubusercontent.com/2886596/130365457-d51f819f-2cce-42fe-a708-0b77f466f9bc.png)

After:

![image](https://user-images.githubusercontent.com/2886596/130365465-d39c44ee-0072-46e9-bdec-d4526e048f90.png)
