### PR TITLE
Improve Discord social button color (footer)

### DIFF
--- a/src/assets/scss/custom/_buttons.scss
+++ b/src/assets/scss/custom/_buttons.scss
@@ -66,6 +66,12 @@
     color: theme-color("primary");
 }
 
+.btn-discord {
+    color: #fff;
+    background: #747df7;
+    border-color: #747df7;
+}
+
 // Icons
 
 .btn svg:not(:first-child),


### PR DESCRIPTION
Improve Discord social button in the footer.

Before:

![image](https://user-images.githubusercontent.com/2886596/130367103-f70946c5-005f-4c9a-8fda-cf6c20ead57e.png)

After:

![image](https://user-images.githubusercontent.com/2886596/130367089-e2d17cb6-268f-4469-9bca-09a2575e4804.png)