### PR TITLE
Improve center text in explorer cases

### DIFF
--- a/src/app/explorer/dashboard/dashboard.component.html
+++ b/src/app/explorer/dashboard/dashboard.component.html
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="row justify-content-center">
       <div class="col-lg-12">
-        <div class="row row-grid">
+        <div class="row row-grid text-center">
           <div class="col-lg-2">
             <div class="card card-lift shadow border-0">
               <div class="card-body py-3">


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2886596/130370584-fb35bba6-97d8-4a30-bc04-4ec3824c672e.png)

After:

![image](https://user-images.githubusercontent.com/2886596/130370569-20c6cf27-8eae-4a81-8e48-40dedc88253b.png)

⚠️ **Warning:** Don't look at the spacing, it's a test with `max-witdh: 1200px` from local