### PR TITLE
Add estimated farmer space in explorer

### DIFF
--- a/src/app/explorer/dashboard/dashboard.component.html
+++ b/src/app/explorer/dashboard/dashboard.component.html
@@ -67,8 +67,8 @@
           <th scope="col">Launcher ID</th>
           <th scope="col" i18n="@@Difficulty">Difficulty</th>
           <th scope="col" i18n="@@Points">Points</th>
-          <th scope="col" i18n="@@Total">Total (%)</th>
-          <th scope="col" i18n="@@Space">Estimated Space (TB)</th>
+          <th scope="col" i18n="@@UtilizationSpace">Utilization Space</th>
+          <th scope="col" i18n="@@EstimatedSpace">Estimated Space</th>
         </tr>
       </thead>
       <tbody>
@@ -80,7 +80,7 @@
           <td>{{ launcher.difficulty }}</td>
           <td>{{ launcher.points }}</td>
           <td>{{ launcher.points_of_total | number:'2.5' }}%</td>
-          <td>{{ launcher.estimated_size / 1024 / 1024 / 1024 / 1024 | number:'1.0' }}</td>
+          <td>{{ launcher.estimated_size | filesize:{"standard": "iec"} }}</td>
         </tr>
         <tr *ngIf="searchNotFound">
           <td colspan="5" i18n>No farmers found!</td>

--- a/src/app/explorer/dashboard/dashboard.component.html
+++ b/src/app/explorer/dashboard/dashboard.component.html
@@ -60,14 +60,15 @@
         <button class="btn btn-neutral" type="button" (click)="searchFarmer()" i18n>Search</button>
       </div>
     </div>
-    <table class="table table-sm table-striped">
+    <table class="table table-sm table-striped text-center">
       <thead>
         <tr>
           <th scope="col">#</th>
           <th scope="col">Launcher ID</th>
           <th scope="col" i18n="@@Difficulty">Difficulty</th>
           <th scope="col" i18n="@@Points">Points</th>
-          <th scope="col" i18n>% of total</th>
+          <th scope="col" i18n="@@Total">Total (%)</th>
+          <th scope="col" i18n="@@Space">Estimated Space (TB)</th>
         </tr>
       </thead>
       <tbody>
@@ -79,6 +80,7 @@
           <td>{{ launcher.difficulty }}</td>
           <td>{{ launcher.points }}</td>
           <td>{{ launcher.points_of_total | number:'2.5' }}%</td>
+          <td>{{ launcher.estimated_size / 1024 / 1024 / 1024 / 1024 | number:'1.0' }}</td>
         </tr>
         <tr *ngIf="searchNotFound">
           <td colspan="5" i18n>No farmers found!</td>


### PR DESCRIPTION
## Feature request:

* Add farmer estimated space in explorer dashboard (TB)
* Align text center

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/2886596/130424877-0dbfc865-6ca2-47a4-be1e-22f8ef41d63f.png)

After:

![image](https://user-images.githubusercontent.com/2886596/130424904-f8079ad9-8dbb-4cc3-bf5e-ee93869a864b.png)