### PR TITLE
Fix language selector desktop/mobile (issue #20)

### DIFF
--- a/src/app/shared/navbar/navbar.component.html
+++ b/src/app/shared/navbar/navbar.component.html
@@ -77,18 +77,18 @@
             <span class="nav-link-inner--text" i18n="@@JoinPool">Join our pool</span>
           </a>
         </li>
-        <li ngbDropdown class="nav-item">
-            <a ngbDropdownToggle class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="languageDropdown" role="button">
-              <i class="ni ni-collection d-lg-none"></i>
-              <span class="nav-link-inner--text">{{ locale | uppercase }}</span>
-            </a>
-            <div class="dropdown-menu" aria-labelledby="languageDropdown" ngbDropdownMenu>
-              <a ngbDropdownItem href="/de/" class="dropdown-item">Deutsch</a>
-              <a ngbDropdownItem href="/en/" class="dropdown-item">English</a>
-              <a ngbDropdownItem href="/fr/" class="dropdown-item">Français</a>
-              <a ngbDropdownItem href="/pl/" class="dropdown-item">Polski</a>
-              <a ngbDropdownItem href="/pt/" class="dropdown-item">Português</a>
-            </div>
+        <li ngbDropdown class="nav-item dropdown">
+          <a ngbDropdownToggle class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="languageDropdown" role="button">
+            <i class="ni ni-collection d-lg-none"></i>
+            <span class="nav-link-inner--text">{{ locale | uppercase }}</span>
+          </a>
+          <div class="dropdown-menu" aria-labelledby="languageDropdown" ngbDropdownMenu>
+            <a ngbDropdownItem href="/de/" class="dropdown-item">Deutsch</a>
+            <a ngbDropdownItem href="/en/" class="dropdown-item">English</a>
+            <a ngbDropdownItem href="/fr/" class="dropdown-item">Français</a>
+            <a ngbDropdownItem href="/pl/" class="dropdown-item">Polski</a>
+            <a ngbDropdownItem href="/pt/" class="dropdown-item">Português</a>
+          </div>
         </li>
       </ul>
     </div>

--- a/src/app/shared/navbar/navbar.component.html
+++ b/src/app/shared/navbar/navbar.component.html
@@ -77,18 +77,18 @@
             <span class="nav-link-inner--text" i18n="@@JoinPool">Join our pool</span>
           </a>
         </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link no-caret" data-toggle="dropdown" role="button">
-            <i class="ni ni-collection d-lg-none"></i>
-            <span class="nav-link-inner--text">{{ locale | uppercase }}</span>
-          </a>
-          <div class="dropdown-menu">
-            <a href="/de/" class="dropdown-item">Deutsch</a>
-            <a href="/en/" class="dropdown-item">English</a>
-            <a href="/fr/" class="dropdown-item">Français</a>
-            <a href="/pl/" class="dropdown-item">Polski</a>
-            <a href="/pt/" class="dropdown-item">Português</a>
-          </div>
+        <li ngbDropdown class="nav-item">
+            <a ngbDropdownToggle class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="languageDropdown" role="button">
+              <i class="ni ni-collection d-lg-none"></i>
+              <span class="nav-link-inner--text">{{ locale | uppercase }}</span>
+            </a>
+            <div class="dropdown-menu" aria-labelledby="languageDropdown" ngbDropdownMenu>
+              <a ngbDropdownItem href="/de/" class="dropdown-item">Deutsch</a>
+              <a ngbDropdownItem href="/en/" class="dropdown-item">English</a>
+              <a ngbDropdownItem href="/fr/" class="dropdown-item">Français</a>
+              <a ngbDropdownItem href="/pl/" class="dropdown-item">Polski</a>
+              <a ngbDropdownItem href="/pt/" class="dropdown-item">Português</a>
+            </div>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Request

* Fix language selection

## Screenshots

Desktop (no major change):

![image](https://user-images.githubusercontent.com/2886596/130687836-3b103c15-66a3-44f4-8333-ffe33dc16ed5.png)

Mobile (after touch current language):

![image](https://user-images.githubusercontent.com/2886596/130687994-a8ed6d8d-3289-404e-bdc5-3c1aa385381a.png)