### PR TITLE
Add 'total transactions', 'total payouts' and export payouts to CSV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@scullyio/scully": "^1.1.1-BETA.62759",
         "@scullyio/scully-plugin-base-href-rewrite": "^1.1.1",
         "@swimlane/ngx-charts": "^18.0.1",
+        "angular-csv-ext": "^1.0.5",
         "jw-bootstrap-switch-ng2": "^2.0.5",
         "moment": "^2.29.1",
         "ng-terminal": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@scullyio/scully": "^1.1.1-BETA.62759",
     "@scullyio/scully-plugin-base-href-rewrite": "^1.1.1",
     "@swimlane/ngx-charts": "^18.0.1",
+    "angular-csv-ext": "^1.0.5",
     "jw-bootstrap-switch-ng2": "^2.0.5",
     "moment": "^2.29.1",
     "ng-terminal": "^3.1.0",

--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -186,9 +186,9 @@
               <div class="row row-grid">
                 <div class="col-lg-4 justify-content-center">
                   <div class="card card-lift shadow border-0">
-                    <div *ngIf="payoutaddrs$ | async; let list" class="card-body py-3 text-center text-uppercase">
+                    <div *ngIf="payoutaddrs$ | async; let payoutaddrs" class="card-body py-3 text-center text-uppercase">
                       <span class="text-primary"><span i18n="">Total transaction(s)</span></span>
-                      <p class="display-3">{{ list.length }}</p>
+                      <p class="display-3">{{ payoutaddrs.length }}</p>
                     </div>
                   </div>
                 </div>
@@ -204,7 +204,10 @@
                   <div class="card card-lift shadow border-0">
                     <div *ngIf="(payoutaddrs$ | async) as payoutaddrs" class="card-body py-3 text-center text-uppercase">
                       <span class="text-primary"><span i18n="">Export CSV</span></span>
-                      <p class="display-3"><button class="btn btn-neutral btn-icon" (click)="payoutDownloadCSV(payoutaddrs)">Download</button></p>
+                      <p class="display-3">
+                        <button *ngIf="payoutaddrs.length>=1" class="btn btn-neutral btn-icon" (click)="payoutDownloadCSV(payoutaddrs)">Download</button>
+                        <button *ngIf="payoutaddrs.length==0" disabled class="btn btn-warning btn-icon" (click)="payoutDownloadCSV(payoutaddrs)">No payout</button>
+                      </p>
                     </div>
                   </div>
                 </div>

--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -180,9 +180,42 @@
       <li class="display-4" [ngbNavItem]="2">
         <a ngbNavLink>Payouts</a>
         <ng-template ngbNavContent>
+          <br/>
+          <div class="row justify-content-center">
+            <div class="col-lg-12">
+              <div class="row row-grid">
+                <div class="col-lg-4 justify-content-center">
+                  <div class="card card-lift shadow border-0">
+                    <div *ngIf="payoutaddrs$ | async; let list" class="card-body py-3 text-center text-uppercase">
+                      <span class="text-primary"><span i18n="">Total transaction(s)</span></span>
+                      <p class="display-3">{{ list.length }}</p>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-lg-4 justify-content-center">
+                  <div class="card card-lift shadow border-0">
+                    <div *ngIf="(payoutaddrs$ | async) as payoutaddrs" class="card-body py-3 text-center text-uppercase">
+                      <span class="text-primary"><span i18n="">Total payout(s)</span></span>
+                      <p class="display-3">{{ payoutGetTotalAmount(payoutaddrs) / 1000000000000 | number:'1.8' }} XCH</p>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-lg-4 justify-content-center">
+                  <div class="card card-lift shadow border-0">
+                    <div *ngIf="(payoutaddrs$ | async) as payoutaddrs" class="card-body py-3 text-center text-uppercase">
+                      <span class="text-primary"><span i18n="">Export CSV</span></span>
+                      <p class="display-3"><button class="btn btn-neutral btn-icon" (click)="payoutDownloadCSV(payoutaddrs)">Download</button></p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <br/>
           <table class="table table-sm table-striped table-responsive-lg">
             <thead>
               <tr>
+                <th scope="col" i18n="@ID">ID</th>
                 <th scope="col" i18n="@@Transaction">Transaction</th>
                 <th scope="col" i18n="@@Date">Date</th>
                 <th scope="col" i18n="@@TransactionBlock">Transaction Block</th>
@@ -191,13 +224,14 @@
             </thead>
             <tbody *ngIf="(payoutaddrs$ | async) as payoutaddrs;">
               <tr *ngFor="let payoutaddr of payoutaddrs; let i = index">
+                <td>{{ payoutaddr.id }}</td>
                 <td>{{ payoutaddr.transaction }}</td>
                 <td>{{ payoutaddr.payout.datetime | date:"medium" }}</td>
                 <td>{{ payoutaddr.confirmed_block_index }}</td>
                 <td>{{ payoutaddr.amount / 1000000000000 }} XCH</td>
               </tr>
               <tr *ngIf="payoutaddrs.length == 0">
-                <td colspan="3" i18n="@@NoPayouts">No payouts found!</td>
+                <td colspan="5" i18n="@@NoPayouts">No payouts found!</td>
               </tr>
             </tbody>
           </table>

--- a/src/app/explorer/farmer/farmer.component.ts
+++ b/src/app/explorer/farmer/farmer.component.ts
@@ -3,6 +3,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { DataService } from '../../data.service';
 import { Observable } from 'rxjs';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { AngularCsv } from 'angular-csv-ext/dist/Angular-csv';
 
 @Component({
   selector: 'app-farmer',
@@ -34,6 +35,8 @@ export class FarmerComponent implements OnInit {
   payoutsCollectionSize: number = 0;
   payoutsPage: number = 1;
   payoutsPageSize: number = 100;
+  payoutsCountTotal: number = 0;
+  payoutsAmountTotal: number = 0;
 
   blocks$: Observable<any[]>;
   blocksCollectionSize: number = 0;
@@ -100,6 +103,29 @@ export class FarmerComponent implements OnInit {
       this.filterPartials();
     }
 
+  }
+
+  payoutGetTotalAmount(datas) {
+    let amount_array = [];
+    const out = Object.keys(datas).map(index => {
+      let data = datas[index];
+      amount_array.push(data['amount']);
+    });
+    return amount_array.reduce((a, b) => a + b, 0);
+  }
+
+  payoutDownloadCSV(datas) {
+    let csv_array = [];
+    const out = Object.keys(datas).map(index => {
+      let data = datas[index];
+      csv_array.push({
+        id: data['id'],
+        datetime: data['payout']['datetime'],
+        transaction: data['transaction'],
+        amount: data['amount'] / 1000000000000        
+      });
+    });
+    new AngularCsv(csv_array, 'payouts');
   }
 
   refreshBlocks(): void {


### PR DESCRIPTION
## Features

On farmer page and payouts tab:
* Total transactions
* Total payouts (XCH)
* Export payouts to CSV

## Screenshots

Default view:
![image](https://user-images.githubusercontent.com/2886596/145718374-2cf4bd26-9587-4638-8ef2-bbdb2e65ad4f.png)

View when the farmer don't receive a payout (button disabled):
![image](https://user-images.githubusercontent.com/2886596/145718541-3e4f0d71-b410-4a7b-b3b2-e34d9d3edde3.png)

And a minor fixe when no payout:
![image](https://user-images.githubusercontent.com/2886596/145718339-99ef4975-0fd2-461f-8d3c-abbb85d2dd4a.png)