### PR TITLE
Fix winner name in giveaway farmer page

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -309,13 +309,13 @@
             <tbody *ngIf="(giveaways$ | async) as giveaways;">
               <tr *ngFor="let giveaway of giveaways; let i = index">
                 <td>{{ giveaway.draw_datetime | date:"medium" }}</td>
-                <td>{{ giveaway.winner || "To be defined" }}</td>
+                <td *ngIf="giveaway.winner">{{ giveaway.winner.name }}</td><td *ngIf="!giveaway.winner">?</td>
                 <td>{{ giveaway.prize_amount / 1000000000000 }} XCH</td>
                 <td>{{ giveaway.issued_tickets || "None" }} (<a href="javascript:void();" (click)="openGiveaway(content)">Show
                     mine</a>)</td>
               </tr>
               <tr *ngIf="giveaways.length == 0">
-                <td colspan="3" i18n>No giveaways available!</td>
+                <td colspan="4" i18n>No giveaways available!</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Fix giveaway winner name in the farmer page

![image](https://user-images.githubusercontent.com/2886596/146991696-676a0be9-8fac-46be-9e05-ddf7c3470223.png)

Here I use ngIf because by default giveaway.winner is null and not empty