### PR TITLE
Use pool size with PiB over TiB on the landing page

### DIFF
--- a/src/app/landing/landing.component.ts
+++ b/src/app/landing/landing.component.ts
@@ -35,7 +35,7 @@ export class LandingComponent implements OnInit {
           return ({
             "name": (new Date(item['date']).toLocaleString()),
             "value": item['size'],
-            "label": (item['size'] / 1024 / 1024 / 1024 / 1024).toFixed(2).toString() + ' TiB',
+            "label": (item['size'] / 1024 / 1024 / 1024 / 1024 / 1024).toFixed(2).toString() + ' PiB',
           })
         })
       }];
@@ -43,7 +43,7 @@ export class LandingComponent implements OnInit {
   }
 
   yAxisFormat(data) {
-    return (data / 1024 / 1024 / 1024 / 1024).toFixed(2).toString() + ' TiB';
+    return (data / 1024 / 1024 / 1024 / 1024 / 1024).toFixed(2).toString() + ' PiB';
   }
 
 }


### PR DESCRIPTION
## Change(s)

* Use PiB over TiB for pool space on the landing page (same value in the explorer page)

## Screenshot(s)

<img width="949" alt="image" src="https://user-images.githubusercontent.com/2886596/147857100-71be6ae7-0ed2-41f2-9264-75bca1b52b39.png">
