### PR TITLE
Add spacescan links

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -371,7 +371,12 @@
                 <td>{{ payoutaddr.id }}</td>
                 <td>{{ payoutaddr.payout.datetime | date:"medium" }}</td>
                 <td>{{ payoutaddr.transaction?.transaction }}</td>
-                <td>{{ payoutaddr.transaction?.confirmed_block_index }}</td>
+                <td>
+                  <a href="https://www.spacescan.io/xch/block/height/{{ payoutaddr.transaction?.confirmed_block_index }}"
+                    target="_blank">
+                    {{ payoutaddr.transaction?.confirmed_block_index }}
+                  </a>
+                </td>
                 <td>{{ payoutaddr.amount / 1000000000000 }} XCH</td>
                 <td>
                   <span *ngIf="payoutaddr.transaction && payoutaddr.transaction.xch_price">${{
@@ -441,7 +446,11 @@
             </thead>
             <tbody *ngIf="(blocks$ | async) as blocks;">
               <tr *ngFor="let block of blocks; let i = index">
-                <td>{{ block.farmed_height }}</td>
+                <td>
+                  <a href="https://www.spacescan.io/xch/block/height/{{ block.farmed_height }}" target="_blank">
+                    {{ block.farmed_height }}
+                  </a>
+                </td>
                 <td>{{ block.timestamp * 1000 | date:"medium" }}</td>
                 <td>{{ block.amount / 1000000000000 }} XCH</td>
                 <td>

--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -371,12 +371,7 @@
                 <td>{{ payoutaddr.id }}</td>
                 <td>{{ payoutaddr.payout.datetime | date:"medium" }}</td>
                 <td>{{ payoutaddr.transaction?.transaction }}</td>
-                <td>
-                  <a href="https://www.spacescan.io/xch/block/height/{{ payoutaddr.transaction?.confirmed_block_index }}"
-                    target="_blank">
-                    {{ payoutaddr.transaction?.confirmed_block_index }}
-                  </a>
-                </td>
+                <td>{{ payoutaddr.transaction?.confirmed_block_index }}</td>
                 <td>{{ payoutaddr.amount / 1000000000000 }} XCH</td>
                 <td>
                   <span *ngIf="payoutaddr.transaction && payoutaddr.transaction.xch_price">${{


### PR DESCRIPTION
## Description

Add spacescan link on farmer and payout pages

## Test(s)

From localhost

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [ ] Mobile

## Screenshot(s)

No

## Reference(s)

Issue #222 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
