### PR TITLE
Move Stats out of More and add Translation

### DIFF
--- a/src/app/shared/footer/footer.component.html
+++ b/src/app/shared/footer/footer.component.html
@@ -35,6 +35,10 @@
       <div class="col-md-6">
         <ul class="nav nav-footer justify-content-end">
           <li class="nav-item">
+            <span class="nav-link"><a target="_blank" href="https://translation.openchia.io/projects/openchia/website/"
+                i18n="@@Translation">Translation</a></span>
+          </li>
+          <li class="nav-item">
             <span class="nav-link"><a [routerLink]="['/faq']" i18n="@@FAQ">FAQ</a></span>
           </li>
           <li class="nav-item">

--- a/src/app/shared/navbar/navbar.component.html
+++ b/src/app/shared/navbar/navbar.component.html
@@ -39,17 +39,19 @@
             <span class="nav-link-inner--text giveaway-bold" i18n="@@Giveaway">Giveaway</span>
           </a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" role="button" [routerLink]="['/stats']">
+            <i class="ni ni-ui-04 d-lg-none"></i>
+            <span class="nav-link-inner--text" i18n="@@Stats">Stats</span>
+          </a>
+        </li>
         <li ngbDropdown class="nav-item dropdown">
-          <a ngbDropdownToggle class="nav-link dropdown-toggle" data-toggle="dropdown"
-            aria-haspopup="true" aria-expanded="false" id="moreDropdown" role="button">
+          <a ngbDropdownToggle class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true"
+            aria-expanded="false" id="moreDropdown" role="button">
             <i class="ni ni-collection d-lg-none"></i>
             <span class="nav-link-inner" i18n="@@More">More</span>
           </a>
           <div class="dropdown-menu" aria-labelledby="moreDropdown" ngbDropdownMenu>
-            <a ngbDropdownItem class="dropdown-item" role="button" [routerLink]="['/stats']">
-              <i class="ni ni-ui-04 d-lg-none"></i>
-              <span class="nav-link-inner text-primary" i18n="@@Stats">Stats</span>
-            </a>
             <a ngbDropdownItem class="dropdown-item" role="button" [routerLink]="['/calculator']">
               <i class="ni ni-ui-04 d-lg-none"></i>
               <span class="nav-link-inner text-primary" i18n="@@Calculator">Calculator</span>


### PR DESCRIPTION
## Description

Move Stats to give more visibility


And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [ ] Mobile

## Screenshot(s)

![image](https://user-images.githubusercontent.com/56250/155852944-e37b951d-43ac-4bd0-9b1f-a2fb86cc3d8c.png)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
