### PR TITLE
Update farmer page translations for declension in Slavic languages

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -115,8 +115,8 @@
                 <div class="col-lg-2 justify-content-center">
                   <div class="card card-lift shadow border-0">
                     <div class="card-body py-3 text-center text-uppercase">
-                      <span class="text-primary"><span i18n="@@Successful">Successful</span><br /><span
-                          i18n="@@Partials">Partials</span></span>
+                      <span class="text-primary"><span i18n="@@SuccessfulPartials_preline" style="white-space: pre-line">Successful
+                        Partials</span></span>
                       <p class="display-3">{{ partialsSuccessful }}</p>
                     </div>
                   </div>
@@ -124,8 +124,8 @@
                 <div class="col-lg-2 justify-content-center">
                   <div class="card card-lift shadow border-0">
                     <div class="card-body py-3 text-center text-uppercase">
-                      <span class="text-warning"><span i18n="@@Failed">Failed</span><br /><span
-                          i18n="@@Partials">Partials</span></span>
+                      <span class="text-warning"><span i18n="@@FailedPartials_preline" style="white-space: pre-line">Failed
+                        Partials</span></span>
                       <p class="display-3">{{ partialsFailed }}</p>
                     </div>
                   </div>
@@ -144,8 +144,8 @@
                 <div class="col-lg-2 justify-content-center">
                   <div class="card card-lift shadow border-0">
                     <div class="card-body py-3 text-center text-uppercase">
-                      <span class="text-primary"><span i18n="@@Harversters">Harvesters</span><br /><span
-                          i18n="@@Count">Count</span></span>
+                      <span class="text-primary"><span i18n="@@HarvesterCount_preline" style="white-space: pre-line">Harvester
+                        Count</span></span>
                       <p class="display-3">{{ harvesters.size }}</p>
                     </div>
                   </div>


### PR DESCRIPTION
A note about HTML syntax (not related to declension): The `<br>` tag doesn't require a slash. The `/` in `<br/>` is redundant in  HTML, however it is required in XHTML.

See also: https://en.wikipedia.org/wiki/Slovak_declension