### PR TITLE
Update farmer page translations for declension in Slavic languages (v2)

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -115,8 +115,7 @@
                 <div class="col-lg-2 justify-content-center">
                   <div class="card card-lift shadow border-0">
                     <div class="card-body py-3 text-center text-uppercase">
-                      <span class="text-primary"><span i18n="@@SuccessfulPartials_preline" style="white-space: pre-line">Successful
-                        Partials</span></span>
+                      <span class="text-primary"><span i18n="@@SuccessfulPartials_2lines">Successful<br>Partials</span></span>
                       <p class="display-3">{{ partialsSuccessful }}</p>
                     </div>
                   </div>
@@ -124,8 +123,7 @@
                 <div class="col-lg-2 justify-content-center">
                   <div class="card card-lift shadow border-0">
                     <div class="card-body py-3 text-center text-uppercase">
-                      <span class="text-warning"><span i18n="@@FailedPartials_preline" style="white-space: pre-line">Failed
-                        Partials</span></span>
+                      <span class="text-warning"><span i18n="@@FailedPartials_2lines">Failed<br>Partials</span></span>
                       <p class="display-3">{{ partialsFailed }}</p>
                     </div>
                   </div>
@@ -144,8 +142,7 @@
                 <div class="col-lg-2 justify-content-center">
                   <div class="card card-lift shadow border-0">
                     <div class="card-body py-3 text-center text-uppercase">
-                      <span class="text-primary"><span i18n="@@HarvesterCount_preline" style="white-space: pre-line">Harvester
-                        Count</span></span>
+                      <span class="text-primary"><span i18n="@@HarvesterCount_2lines">Harvester<br>Count</span></span>
                       <p class="display-3">{{ harvesters.size }}</p>
                     </div>
                   </div>


### PR DESCRIPTION
Newlines in the file `farmer.component.html` are being replaced with ordinary spaces by http://translation.openchia.io and become ordinary spaces in https://openchia.io/en/explorer/farmer/...

This patch uses `<br>` instead of newline characters.

Previous version: https://github.com/openchia/web/pull/240
See also: https://en.wikipedia.org/wiki/Slovak_declension