### PR TITLE
Add clipboard copy on join page

### DIFF
--- a/src/app/join/join.component.html
+++ b/src/app/join/join.component.html
@@ -56,12 +56,20 @@
                       </ul><br />
                       <span i18n>Depending on your location, use one of the following connections</span>:
                       <ul>
-                        <li><span i18n>Global server</span>: <a
-                            href="https://pool.openchia.io">https://pool.openchia.io</a></li>
-                        <li><span i18n>Europe server</span>: <a
-                            href="https://pool-eu.openchia.io">https://pool-eu.openchia.io</a></li>
-                        <li><span i18n>Asia server</span>: <a
-                            href="https://pool-asia.openchia.io">https://pool-asia.openchia.io</a></li>
+                        <li>
+                          <span i18n>Global server</span>:
+                          <a href="https://pool.openchia.io">https://pool.openchia.io</a>
+                          <i class="fas fa-copy fa-copy-join" (click)="copyToClipboard('https://pool.openchia.io')"></i>
+                        </li>
+                        <li>
+                          <span i18n>Europe server</span>:
+                          <a href="https://pool-eu.openchia.io">https://pool-eu.openchia.io</a>
+                          <i class="fas fa-copy fa-copy-join" (click)="copyToClipboard('https://pool-eu.openchia.io')"></i>
+                        </li>
+                        <li><span i18n>Asia server</span>:
+                          <a href="https://pool-asia.openchia.io">https://pool-asia.openchia.io</a>
+                          <i class="fas fa-copy fa-copy-join" (click)="copyToClipboard('https://pool-asia.openchia.io')"></i>
+                        </li>
                       </ul>
                     </div>
                   </div>

--- a/src/app/join/join.component.scss
+++ b/src/app/join/join.component.scss
@@ -1,0 +1,5 @@
+.fa-copy-join {
+  padding-left: 5px;
+  color: #525f7f;
+}
+  

--- a/src/app/join/join.component.ts
+++ b/src/app/join/join.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ClipboardService } from 'ngx-clipboard';
 
 @Component({
     selector: 'app-landing',
@@ -10,8 +11,12 @@ export class JoinComponent implements OnInit {
   focus: any;
   focus1: any;
 
-  constructor() { }
+  constructor(private clipboardApi: ClipboardService) { }
 
   ngOnInit() {}
+
+  copyToClipboard(content) {
+    this.clipboardApi.copyFromContent(content);
+  }
 
 }


### PR DESCRIPTION
## Description

Add copy clipboard function on join page

## Test(s)

Only from localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [x] Mobile

## Screenshot(s)

![image](https://user-images.githubusercontent.com/2886596/158064172-6ff89bc7-3bf7-464e-ae1b-9ae1ea6792d5.png)

## Reference(s)

Issue #239 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
