### PR TITLE
Improve space chart colors

### DIFF
--- a/src/app/stats/stats.component.ts
+++ b/src/app/stats/stats.component.ts
@@ -66,7 +66,7 @@ export class StatsComponent implements OnInit {
 
   blocksColorScheme = { domain: ['#149b00'] };
 
-  colorScheme = { domain: ['#149b00', '#006400', '#9ef01a'] };
+  colorScheme = { domain: ['#006400', '#9ef01a', '#008000', '#70e000'] };
 
   constructor(private dataService: DataService) { }
 


### PR DESCRIPTION
## Description

Improve space chart color in stats page

## Test(s)

From localhost, with light and dark mode

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [ ] Mobile

## Screenshot(s)

Light mode:

![image](https://user-images.githubusercontent.com/2886596/159777457-09398d1c-c5c9-49d0-b678-774e7cea2020.png)

Dark mode:

![image](https://user-images.githubusercontent.com/2886596/159777523-8b949ba0-6f6b-40df-a3f3-9b5b73c23667.png)

## Reference(s)

Issue #261 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
