### PR TITLE
Improve payout page when no transaction

### DIFF
--- a/src/app/explorer/payout/payout.component.html
+++ b/src/app/explorer/payout/payout.component.html
@@ -45,6 +45,7 @@
           <th scope="col" i18n="@@Transaction">Transaction</th>
           <th scope="col" i18n="@@Amount">Amount</th>
           <th scope="col" i18n="@@Price">Price</th>
+          <th scope="col" i18n="@@State">State</th>
         </tr>
       </thead>
       <tbody *ngIf="(payoutaddrs$ | async) as payoutaddrs;">
@@ -56,20 +57,28 @@
               {{ (payoutaddr.launcher?.name || payoutaddr.launcher?.launcher_id || '') | maxLength:20 }}
             </a>
           </td>
-          <td>
-            <ng-template #noTransactionTooltip>
-              <span i18n>Minimum payout has not been reached.</span>
-            </ng-template>
-            <span *ngIf="payoutaddr.transaction?.transaction">{{ payoutaddr.transaction?.transaction }}</span>
-            <span *ngIf="!payoutaddr.transaction?.transaction">
-              None <i class="fas fa-info-circle" closeDelay="4000" [ngbTooltip]="noTransactionTooltip"></i>
-            </span>
-          </td>
+          <td>{{ payoutaddr.transaction?.transaction }}</td>
           <td>{{ payoutaddr.amount / 1000000000000 }} XCH</td>
           <td>
             <span *ngIf="payoutaddr.transaction && payoutaddr.transaction.xch_price">${{
               payoutaddr.transaction.xch_price.usd * (payoutaddr.amount / 1000000000000) | number }} USD</span>
             <span *ngIf="!payoutaddr.transaction || !payoutaddr.transaction.xch_price" i18n="@@Unknown">Unknown</span>
+          </td>
+          <td>
+            <ng-template #pendingTransactionTooltip>
+              <span i18n>
+                The minimum payout has not been reached, transaction will be made at the next payment.
+              </span>
+            </ng-template>
+            <span *ngIf="payoutaddr.transaction?.transaction"
+              class="badge badge-pill badge-success" i18n>
+              Confirmed
+            </span>
+            <span *ngIf="!payoutaddr.transaction?.transaction"
+              closeDelay="4000" [ngbTooltip]="pendingTransactionTooltip"
+              class="badge badge-pill badge-warning" i18n>
+              Pending <i class="fas fa-info-circle"></i>
+            </span>
           </td>
         </tr>
         <tr *ngIf="payoutaddrs.length == 0">

--- a/src/app/explorer/payout/payout.component.html
+++ b/src/app/explorer/payout/payout.component.html
@@ -56,7 +56,15 @@
               {{ (payoutaddr.launcher?.name || payoutaddr.launcher?.launcher_id || '') | maxLength:20 }}
             </a>
           </td>
-          <td>{{ payoutaddr.transaction?.transaction }}</td>
+          <td>
+            <ng-template #noTransactionTooltip>
+              <span i18n>Minimum payout has not been reached.</span>
+            </ng-template>
+            <span *ngIf="payoutaddr.transaction?.transaction">{{ payoutaddr.transaction?.transaction }}</span>
+            <span *ngIf="!payoutaddr.transaction?.transaction">
+              None <i class="fas fa-info-circle" closeDelay="4000" [ngbTooltip]="noTransactionTooltip"></i>
+            </span>
+          </td>
           <td>{{ payoutaddr.amount / 1000000000000 }} XCH</td>
           <td>
             <span *ngIf="payoutaddr.transaction && payoutaddr.transaction.xch_price">${{

--- a/src/app/explorer/payout/payout.component.html
+++ b/src/app/explorer/payout/payout.component.html
@@ -71,13 +71,13 @@
               </span>
             </ng-template>
             <span *ngIf="payoutaddr.transaction?.transaction"
-              class="badge badge-pill badge-success" i18n>
-              Confirmed
+              class="badge badge-pill badge-success">
+              <span i18n>Confirmed</span>
             </span>
             <span *ngIf="!payoutaddr.transaction?.transaction"
               closeDelay="4000" [ngbTooltip]="pendingTransactionTooltip"
-              class="badge badge-pill badge-warning" i18n>
-              Pending <i class="fas fa-info-circle"></i>
+              class="badge badge-pill badge-warning">
+              <span i18n>Pending</span>&nbsp;<i class="fas fa-info-circle"></i>
             </span>
           </td>
         </tr>

--- a/src/assets/scss/custom/_badge.scss
+++ b/src/assets/scss/custom/_badge.scss
@@ -93,3 +93,8 @@
     color: #fff;
     background-color: #f91f1f;
 }
+
+.badge-warning {
+    color: #fff;
+    background-color: #ff8c00;
+}


### PR DESCRIPTION
## Description

Improve payout page with a state of payment

## Test(s)

From localhost, with light/dark mode

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [x] Mobile

## Screenshot(s)

![image](https://user-images.githubusercontent.com/2886596/160232688-d92db79b-4add-4cb4-93bd-27b5ed2374f0.png)

![image](https://user-images.githubusercontent.com/2886596/160232770-e6a7434c-4559-4c57-8049-03caef8eeadf.png)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
