### PR TITLE
Add a warning icon in the navbar if duststorm is true

### DIFF
--- a/src/app/shared/navbar/navbar.component.html
+++ b/src/app/shared/navbar/navbar.component.html
@@ -65,6 +65,17 @@
         </li>
       </ul>
       <ul class="navbar-nav navbar-nav-hover align-items-lg-center ml-lg-auto">
+        <li *ngIf="blockchain_duststorm" class="nav-item">
+          <ng-template #duststormTooltip>
+            <span i18n>
+              Dust storm currently affecting the blockchain. Payouts may be delayed.
+            </span>
+          </ng-template>
+          <a class="nav-link nav-link-icon">
+            <i class="fa-solid fa-triangle-exclamation fa-triangle-duststorm"
+              [ngbTooltip]="duststormTooltip" placement="left auto"></i>
+          </a>
+        </li>
         <li class="nav-item">
           <a class="nav-link nav-link-icon" (click)="darkModeToggle()" href="javascript:void(0);" data-toggle="tooltip"
             title="Toggle Dark Mode"><i #darkModeIcon class="fa-solid fa-moon"></i>

--- a/src/app/shared/navbar/navbar.component.scss
+++ b/src/app/shared/navbar/navbar.component.scss
@@ -1,3 +1,7 @@
 .giveaway-bold {
     font-weight: bold;
 }
+
+.fa-triangle-duststorm {
+    color: #ffd700;
+}

--- a/src/app/shared/navbar/navbar.component.ts
+++ b/src/app/shared/navbar/navbar.component.ts
@@ -1,6 +1,7 @@
 import { LOCALE_ID, Component, Inject, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { Router, NavigationEnd, NavigationStart } from '@angular/router';
 import { Location, PopStateEvent } from '@angular/common';
+import { DataService } from '../../data.service';
 
 @Component({
     selector: 'app-navbar',
@@ -12,10 +13,17 @@ export class NavbarComponent implements OnInit {
     private lastPoppedUrl: string;
     private yScrollStack: number[] = [];
     private darkMode: boolean = false;
+
+    blockchain_duststorm: boolean = false;
+
     @ViewChild('darkModeIcon') darkModeIcon: ElementRef;
 
-    constructor(public location: Location, private router: Router, @Inject(LOCALE_ID) public locale: string) {
-    }
+    constructor(
+        private dataService: DataService,
+        public location: Location,
+        private router: Router,
+        @Inject(LOCALE_ID) public locale: string
+    ) {}
 
     ngOnInit() {
         this.router.events.subscribe((event) => {
@@ -34,8 +42,11 @@ export class NavbarComponent implements OnInit {
         this.location.subscribe((ev: PopStateEvent) => {
             this.lastPoppedUrl = ev.url;
         });
-
+        this.dataService.getStats().subscribe(data => {
+            this.blockchain_duststorm = data['blockchain_duststorm'];
+        });
     }
+
     ngAfterViewInit() {
         var darkMode = localStorage.getItem("darkmode");
         if(darkMode != '') {
@@ -69,4 +80,5 @@ export class NavbarComponent implements OnInit {
         }
         localStorage.setItem("darkmode", `${this.darkMode}`);
     }
+
 }


### PR DESCRIPTION
## Description

Add a warning icon in the navbar if dust storm is true

## Test(s)

From localhost, with light/dark mode. Call to /stats is checked and it's good 👍 

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [ ] Mobile

## Screenshot(s)

![image](https://user-images.githubusercontent.com/2886596/160461619-158c1b6f-edfe-48e4-a214-152f964c728b.png)

## Reference(s)

Issue #259 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
