### PR TITLE
Update npm modules (npm audit fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,6 @@
         "core-js": "3.20.3",
         "critters": "0.0.16",
         "css-loader": "6.5.1",
-        "esbuild": "0.14.14",
         "esbuild-wasm": "0.14.14",
         "glob": "7.2.0",
         "https-proxy-agent": "5.0.0",
@@ -373,7 +372,6 @@
       "integrity": "sha512-cT5DIaz+NI9IGb3X61Wh26+L6zdRcOXT1BP37iRbK2Qa2qM8/0VNeK6hrBBIblyoHKR/WUmRlS8XYf6mmArpZw==",
       "peer": true,
       "dependencies": {
-        "parse5": "^5.0.0",
         "tslib": "^2.3.0"
       },
       "optionalDependencies": {
@@ -3472,9 +3470,9 @@
       "dev": true
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -4109,7 +4107,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -5706,26 +5703,6 @@
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
-      "dependencies": {
-        "esbuild-android-arm64": "0.14.14",
-        "esbuild-darwin-64": "0.14.14",
-        "esbuild-darwin-arm64": "0.14.14",
-        "esbuild-freebsd-64": "0.14.14",
-        "esbuild-freebsd-arm64": "0.14.14",
-        "esbuild-linux-32": "0.14.14",
-        "esbuild-linux-64": "0.14.14",
-        "esbuild-linux-arm": "0.14.14",
-        "esbuild-linux-arm64": "0.14.14",
-        "esbuild-linux-mips64le": "0.14.14",
-        "esbuild-linux-ppc64le": "0.14.14",
-        "esbuild-linux-s390x": "0.14.14",
-        "esbuild-netbsd-64": "0.14.14",
-        "esbuild-openbsd-64": "0.14.14",
-        "esbuild-sunos-64": "0.14.14",
-        "esbuild-windows-32": "0.14.14",
-        "esbuild-windows-64": "0.14.14",
-        "esbuild-windows-arm64": "0.14.14"
-      },
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8198,7 +8175,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -8532,14 +8508,7 @@
       "dev": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
-        "errno": "^0.1.1",
-        "graceful-fs": "^4.1.2",
-        "image-size": "~0.5.0",
-        "make-dir": "^2.1.0",
-        "mime": "^1.4.1",
-        "needle": "^2.5.2",
         "parse-node-version": "^1.0.1",
-        "source-map": "~0.6.0",
         "tslib": "^2.3.0"
       },
       "bin": {
@@ -9082,7 +9051,6 @@
       "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
       "dev": true,
       "dependencies": {
-        "encoding": "^0.1.12",
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.0.0"
@@ -9166,9 +9134,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
       "engines": {
         "node": "*"
       }
@@ -10207,8 +10175,7 @@
       "dependencies": {
         "eventemitter-asyncresource": "^1.0.0",
         "hdr-histogram-js": "^2.0.1",
-        "hdr-histogram-percentiles-obj": "^3.0.0",
-        "nice-napi": "^1.0.2"
+        "hdr-histogram-percentiles-obj": "^3.0.0"
       },
       "optionalDependencies": {
         "nice-napi": "^1.0.2"
@@ -16346,9 +16313,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"
@@ -20662,9 +20629,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
     },
     "ms": {
       "version": "2.1.2",


### PR DESCRIPTION
## Description

Update npm modules:

```
async  <2.6.4
Severity: high
Prototype Pollution in async - https://github.com/advisories/GHSA-fwr7-v2mv-hh25
fix available via `npm audit fix`
node_modules/async

moment  <2.29.2
Severity: high
Path Traversal: 'dir/../../filename' in moment.locale - https://github.com/advisories/GHSA-8hfj-j24r-96c4
fix available via `npm audit fix`
node_modules/moment

2 high severity vulnerabilities
```

## Test(s)

Localhost only.

And through the environments (browser):

- [ ] Desktop
- [ ] Tablet
- [ ] Mobile

## Screenshot(s)

Please include a screenshot if possible.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
