### PR TITLE
Add chia client version and pool connected

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -44,6 +44,12 @@
           </td>
         </tr>
         <tr>
+          <th i18n="@@ClientVersion">Client Version</th>
+          <td>{{ partialsFiltered[0].chia_version }}</td>
+          <th i18n="@@PoolConnected">Pool Connected</th>
+          <td>{{ partialsFiltered[0].pool_host }}</td>
+        </tr>
+        <tr>
           <th i18n="@@Difficulty">Difficulty</th>
           <td>{{ farmer.difficulty }}</td>
           <th><span i18n>Estimated Size</span>&nbsp;<i class="fas fa-info-circle"

--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -45,9 +45,11 @@
         </tr>
         <tr>
           <th i18n="@@ClientVersion">Client Version</th>
-          <td>{{ partialsFiltered[0].chia_version }}</td>
+          <td *ngIf="partialsFiltered[0]">{{ partialsFiltered[0].chia_version }}</td>
+          <td *ngIf="!partialsFiltered[0]" i18n>Unknown</td>
           <th i18n="@@PoolConnected">Pool Connected</th>
-          <td>{{ partialsFiltered[0].pool_host }}</td>
+          <td *ngIf="partialsFiltered[0]">{{ partialsFiltered[0].pool_host }}</td>
+          <td *ngIf="!partialsFiltered[0]" i18n>Unknown</td>
         </tr>
         <tr>
           <th i18n="@@Difficulty">Difficulty</th>
@@ -81,7 +83,7 @@
             </ng-template>
             <i class="fas fa-info-circle" [ngbTooltip]="currentEffortTooltip"></i>
           </th>
-          <td *ngIf="(farmer.current_effort || 0) >= 0">{{ farmer.current_effort | number }}%</td>
+          <td *ngIf="(farmer.current_effort || 0) > 0">{{ farmer.current_effort | number }}%</td>
           <td *ngIf="farmer.current_effort == null" i18n>Unknown</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Description

Added in farmer page:
* Client Version (Chia)
* Pool Connected

Details based on the last partial sent.

## Test(s)

From localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [x] Mobile

## Screenshot(s)

![image](https://user-images.githubusercontent.com/2886596/164214736-cbf69fbe-e0fe-4604-a79c-99637cd64969.png)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
