### PR TITLE
Improve farmer page (issue #302 and #297)

### DIFF
--- a/src/app/explorer/farmer/farmer.component.css
+++ b/src/app/explorer/farmer/farmer.component.css
@@ -7,16 +7,18 @@
   color: #ff0000 !important;
 }
 
-.btn-openchia {
-  background-color: #129b00;
-  border-color: #129b00;
-  color: white;
-}
-
 .fa-copy-farmer {
   padding-right: 4px;
 }
 
 .fa-check-farmer {
   color: #129b00
+}
+
+.fa-caret-down-color {
+ color: #e84256;
+}
+
+.fa-caret-up-color {
+  color: #00b87a;
 }

--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -94,19 +94,49 @@
             &nbsp;<i class="fas fa-info-circle" closeDelay="4000" [ngbTooltip]="estimatedrewardDayTooltip"></i>
           </th>
           <td>
-            {{ xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) | number:".4" }} XCH /day
+            {{ xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) | number:".4" }} XCH / <span i18n>day</span>
             (${{ xch_current_price_usd * (xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024)) |
             number:".2" }})
           </td>
           <td>
-            {{ xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) * 7 | number:".4" }} XCH / week
+            {{ xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) * 7 | number:".4" }} XCH / <span i18n>week</span>
             (${{ xch_current_price_usd * (xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) * 7) |
             number:".2" }})
           </td>
           <td>
-            {{ xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) * 31 | number:".4" }} XCH / month
+            {{ xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) * 31 | number:".4" }} XCH / <span i18n>month</span>
             (${{ xch_current_price_usd * (xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) * 31) |
             number:".2" }})
+          </td>
+        </tr>
+        <tr>
+          <th scope="col"><span i18n="@@EarnedRewardDay">Earned Reward</span>
+            <ng-template #earnedrewardDayTooltip>
+              <span i18n>Icons <i class="fas fa-caret-down fa-caret-down-color"></i> and <i class="fas fa-caret-up fa-caret-up-color"></i>
+              are based from estimated rewards. Value rounded to 4 decimal (show details on <b>Rewards</b> tab).</span>
+            </ng-template>
+            &nbsp;<i class="fas fa-info-circle" closeDelay="4000" [ngbTooltip]="earnedrewardDayTooltip"></i>
+          </th>
+          <td>
+            {{ farmer.rewards.last_24h / 1000000000000 | number:".4" }} XCH / <span i18n>day</span>&nbsp;
+            <i *ngIf="(xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024)) > (farmer.rewards.last_24h / 1000000000000)"
+              class="fas fa-caret-down fa-caret-down-color"></i>
+            <i *ngIf="(xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024)) < (farmer.rewards.last_24h / 1000000000000)"
+              class="fas fa-caret-up fa-caret-up-color"></i>
+          </td>
+          <td>
+            {{ farmer.rewards.last_7d / 1000000000000 | number:".4" }} XCH / <span i18n>week</span>&nbsp;
+            <i *ngIf="(xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) * 7) > (farmer.rewards.last_7d / 1000000000000)"
+              class="fas fa-caret-down fa-caret-down-color"></i>
+            <i *ngIf="(xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) * 7) < (farmer.rewards.last_7d / 1000000000000)"
+              class="fas fa-caret-up fa-caret-up-color"></i>
+          </td>
+          <td>
+            {{ farmer.rewards.last_30d / 1000000000000 | number:".4" }} XCH / <span i18n>month</span>&nbsp;
+            <i *ngIf="(xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) * 31) > (farmer.rewards.last_30d / 1000000000000)"
+              class="fas fa-caret-down fa-caret-down-color"></i>
+            <i *ngIf="(xch_tb_month * (farmer.estimated_size / 1024 / 1024 / 1024 / 1024) * 31) < (farmer.rewards.last_30d / 1000000000000)"
+              class="fas fa-caret-up fa-caret-up-color"></i>
           </td>
         </tr>
       </tbody>
@@ -553,9 +583,9 @@
                     <div *ngIf="(payouttxs$ | async) as payouttxs" class="card-body py-3 text-center text-uppercase">
                       <span class="text-primary"><span i18n="">Export CSV</span></span>
                       <p class="display-3">
-                        <button *ngIf="payouttxs.length>=1" class="btn btn-neutral btn-icon btn-openchia"
+                        <button *ngIf="payouttxs.length>=1" class="btn btn-primary btn-icon"
                           (click)="payoutDownloadCSV()">Download</button>
-                        <button *ngIf="payouttxs.length==0" disabled class="btn btn-warning btn-icon btn-openchia">No
+                        <button *ngIf="payouttxs.length==0" disabled class="btn btn-primary btn-icon disabled">No
                           payout</button>
                       </p>
                     </div>


### PR DESCRIPTION
## Description

Improve farmer page:

* [fix] color of downloads button (payout tab) when dark mode is enabled
* [add] earned rewards with icons (based from estimated rewards)

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [x] Mobile

## Screenshot(s)

Download button (before/after):

![image](https://user-images.githubusercontent.com/2886596/173914525-4db432de-b829-41c7-91c1-005f7033e52a.png)

![image](https://user-images.githubusercontent.com/2886596/173914371-3ca5969d-9ad6-42cb-a8a6-6c7448cf238f.png)

Earned rewards (light/dark mode):

![image](https://user-images.githubusercontent.com/2886596/173914777-419fb387-0c44-41f3-900f-1e2377762e91.png)

![image](https://user-images.githubusercontent.com/2886596/173914833-0a0be9a2-f93a-4998-a7af-90f6d8a0f6b4.png)

## Reference(s)

* #302
* #297 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
