### PR TITLE
Add icons (loading and not found) in farmer page

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -1,9 +1,11 @@
 <section class="section section-sm pt-sm">
   <div *ngIf="!farmer.launcher_id && (farmer | json) == '{}'" class="container">
     <div class="alert alert-info alert-loading" role="alert">
+      <i class="fa-solid fa-spinner"></i>&nbsp;
       <span i18n>Loading farmer details...</span>
     </div>
     <div class="alert alert-warning alert-notfound" role="alert">
+      <i class="fa-solid fa-triangle-exclamation"></i>&nbsp;
       <strong i18n="@@Warning">Warning</strong>: <span i18n>farmer doesn't exist (404).</span>
     </div>
   </div>


### PR DESCRIPTION
## Description

Add icons in farmer page

## Test(s)

From localhost

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [ ] Mobile

## Screenshot(s)

Loading:

![image](https://user-images.githubusercontent.com/2886596/193449788-6aeb81cd-55de-46b0-9fef-b5b1298abc60.png)

Not found:

![image](https://user-images.githubusercontent.com/2886596/193449808-6949d69b-db62-4d8e-878e-9ff8aacb7f27.png)

## Reference(s)

No

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
