### PR TITLE
feat: set safari tab colors (based from system preferences)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -21,6 +21,8 @@
 <head>
   <base href="/">
   <meta charset="utf-8">
+  <meta name="theme-color" content="#149b00" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#588746" media="(prefers-color-scheme: dark)">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="The first open source Chia farming pool. Official pooling protocol.">
   <title>OpenChia.io - Chia Farming Pool</title>


### PR DESCRIPTION
## Description

Set Safari tab colors, based from system preferences (light/dark mode)

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [x] Mobile

## Screenshot(s)

Before:

<img width="1673" alt="image" src="https://user-images.githubusercontent.com/2886596/221413147-4eacdd56-b104-4702-aa3e-a17ec558b0a3.png">

After, light system and website:

<img width="1676" alt="image" src="https://user-images.githubusercontent.com/2886596/221413207-a1574a44-d9dd-4ff0-b623-377f543f90d5.png">

Also dark system and website:

<img width="1677" alt="image" src="https://user-images.githubusercontent.com/2886596/221413298-6567eea1-afd4-4572-af48-46fd5ea0f900.png">

## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
