### PR TITLE
feat: improve blocks luck view

### DIFF
--- a/src/app/explorer/dashboard/dashboard.component.css
+++ b/src/app/explorer/dashboard/dashboard.component.css
@@ -1,3 +1,7 @@
 .farmers-padding-left {
   padding-left: 20px;
 }
+
+.badge-block-luck {
+  width: 110px;
+}

--- a/src/app/explorer/dashboard/dashboard.component.html
+++ b/src/app/explorer/dashboard/dashboard.component.html
@@ -249,13 +249,17 @@
           </td>
           <td>{{ block.pool_space | filesize:{"base": 2, "standard": "iec"} }}</td>
           <td>
-            <span *ngIf="block.luck == -1" i18n="@@Unknown">Unknown</span>
+            <span *ngIf="block.luck == -1"
+              class="badge badge-block-luck badge-secondary" i18n="@@Unknown">
+              Unknown
+            </span>
             <span *ngIf="block.luck != -1">
-              {{ block.luck }}% (
-              <span *ngIf="block.luck < 80" i18n="@@Lucky">Lucky</span>
-              <span *ngIf="block.luck >= 80 && block.luck <= 120" i18n="@@Average">Average</span>
-              <span *ngIf="block.luck > 120" i18n="@@Unlucky">Unlucky</span>
-              )
+              <span *ngIf="block.luck < 80"
+                class="badge badge-block-luck badge-success">{{ block.luck }}%</span>
+              <span *ngIf="block.luck >= 80 && block.luck <= 120"
+                class="badge badge-block-luck badge-warning">{{ block.luck }}%</span>
+              <span *ngIf="block.luck > 120"
+                class="badge badge-block-luck badge-danger">{{ block.luck }}%</span>
             </span>
           </td>
         </tr>

--- a/src/assets/scss/custom/toggle-bootstrap-dark.scss
+++ b/src/assets/scss/custom/toggle-bootstrap-dark.scss
@@ -37,6 +37,18 @@ body.bootstrap-dark {
     .page-item.disabled .page-link {
         background-color: #212529;
     }
+
+    .badge-success {
+        background-color: #588746;
+    }
+
+    .badge-warning {
+        background-color: #d0912b;
+    }
+
+    .badge-danger {
+        background-color: #e74c3c;
+    }
 }
 
 .bootstrap-dark {


### PR DESCRIPTION
## Description

Improve view of pool effort in dashboard
Also badge colors for darkmode are general

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [x] Mobile

## Screenshot(s)

![image](https://user-images.githubusercontent.com/2886596/221901937-24e39520-3618-4b8d-abaa-6609bed2c080.png)

![image](https://user-images.githubusercontent.com/2886596/221902022-0dfe0a53-5900-41e4-a9ae-840815254d79.png)

> Between 80 and 120, it's orange

## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

