### PR TITLE
feat: improve stats luck chart (per block)

### DIFF
--- a/src/app/stats/stats.component.html
+++ b/src/app/stats/stats.component.html
@@ -124,13 +124,16 @@
                       </h5>
                     </div>
                     <div aria-labelledby="headingOne" class="show collapse in" style="display: block;"
-                      aria-expanded="false" aria-hidden="false" #luckContainerRef>
+                      aria-expanded="false" aria-hidden="false" #luckPerBlockContainerRef>
                       <br />
-                      <ngx-charts-bar-vertical [view]="[luckContainerRef.offsetWidth]"
-                        [showXAxisLabel]="luckShowAxisXLabel" [showYAxisLabel]="luckShowAxisYLabel"
-                        [yAxis]="luckAxisY" [xAxis]="luckAxisX" [animations]="luckAnimations"
-                        [results]="luckData" [scheme]="oneColorScheme" [yAxisTickFormatting]="luckFormatAxisY"
-                        [gradient]="luckGradient" [showGridLines]="true">
+                      <!-- per block -->
+                      <ngx-charts-bar-vertical [view]="[luckPerBlockContainerRef.offsetWidth]"
+                        [legend]="luckPerBlockLegend" [legendTitle]="luckPerBlockLegendTitle"
+                        [showXAxisLabel]="luckPerBlockShowAxisXLabel" [showYAxisLabel]="luckPerBlockShowAxisYLabel"
+                        [yAxis]="luckPerBlockAxisY" [xAxis]="luckPerBlockAxisX" [animations]="luckPerBlockAnimations"
+                        [results]="luckPerBlockData" [scheme]="oneColorScheme" [yAxisTickFormatting]="luckPerBlockFormatAxisY"
+                        [gradient]="luckPerBlockGradient" [showGridLines]="true" [barPadding]="3"
+                        [roundEdges]="false" [noBarWhenZero]="false">
                         <ng-template #tooltipTemplate let-model="model">
                           {{ model.name }}<br />Luck {{ model.value }}%
                         </ng-template>

--- a/src/app/stats/stats.component.ts
+++ b/src/app/stats/stats.component.ts
@@ -73,13 +73,15 @@ export class StatsComponent implements OnInit {
   mempoolShowAxisYLabel: boolean = false;
   mempoolData: any[] = null;
 
-  luckAnimations: boolean = true;
-  luckGradient: boolean = true;
-  luckAxisX: boolean = false;
-  luckAxisY: boolean = true;
-  luckShowAxisXLabel: boolean = true;
-  luckShowAxisYLabel: boolean = false;
-  luckData: any[] = null;
+  luckPerBlockLegend: boolean = true;
+  luckPerBlockLegendTitle: string = 'Per block'
+  luckPerBlockAnimations: boolean = true;
+  luckPerBlockGradient: boolean = true;
+  luckPerBlockAxisX: boolean = false;
+  luckPerBlockAxisY: boolean = true;
+  luckPerBlockShowAxisXLabel: boolean = true;
+  luckPerBlockShowAxisYLabel: boolean = false;
+  luckPerBlockData: any[] = null;
 
   oneColorScheme = { domain: ['#149b00'] };
   multiColorScheme = { domain: ['#006400', '#9ef01a', '#008000', '#70e000'] };
@@ -187,16 +189,16 @@ export class StatsComponent implements OnInit {
         })
       });
       this.blocksData = seriesBlocks.reverse();
-      // used in pool luck chart
-      var seriesLuck = [];
+      // used in pool luck chart (per block)
+      var seriesLuckPerBlock = [];
       (<any[]>d['results']).map((item) => {
-        seriesLuck.push({
+        seriesLuckPerBlock.push({
           "name": item['farmed_height'].toString() + ", " + (new Date(Math.floor(item['timestamp'] / 86400 + 1) * 86400 * 1000).toLocaleDateString()),
           "value": item['luck'],
           "label": `Luck ${item['luck']}%`
         })
       })
-      this.luckData = seriesLuck.reverse();
+      this.luckPerBlockData = seriesLuckPerBlock.reverse();
     });
   }
 
@@ -216,7 +218,7 @@ export class StatsComponent implements OnInit {
     return (data).toFixed(0).toString() + '%';
   }
 
-  luckFormatAxisY(data: number) {
+  luckPerBlockFormatAxisY(data: number) {
     return (data).toFixed(0).toString() + '%';
   }
 


### PR DESCRIPTION
## Description

Improve block luck chart in stats page. Display per block because I prepare a new PR with per day view.

## Test(s)

Yes localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [ ] Mobile

## Screenshot(s)

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/2886596/222241510-475c30c7-92d8-42ff-b752-7f6670acb103.png">

## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
