### PR TITLE
feat: add block luck average (block tab) in farmer page

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -660,11 +660,19 @@
           <div class="row justify-content-center">
             <div class="col-lg-12">
               <div class="row row-grid">
-                <div class="col-lg-12 justify-content-center">
+                <div class="col-lg-6 justify-content-center">
                   <div class="card card-lift shadow border-0">
                     <div *ngIf="blocks$ | async; let blocks" class="card-body py-3 text-center text-uppercase">
                       <span class="text-primary"><span i18n="">Total block(s)</span></span>
                       <p class="display-3">{{ blocksCollectionSize }}</p>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-lg-6 justify-content-center">
+                  <div class="card card-lift shadow border-0">
+                    <div *ngIf="blocks$ | async; let blocks" class="card-body py-3 text-center text-uppercase">
+                      <span class="text-primary"><span i18n="">Luck Average</span></span>
+                      <p class="display-3">{{ blocksLuckAverage | number:'.0-1' }}%</p>
                     </div>
                   </div>
                 </div>

--- a/src/app/explorer/farmer/farmer.component.ts
+++ b/src/app/explorer/farmer/farmer.component.ts
@@ -79,6 +79,7 @@ export class FarmerComponent implements OnInit {
   blocksCollectionSize: number = 0;
   blocksPage: number = 1;
   blocksPageSize: number = 25;
+  blocksLuckAverage: number = 0;
 
   giveaways$: Observable<any[]>;
 
@@ -187,6 +188,11 @@ export class FarmerComponent implements OnInit {
   }
 
   private handleBlocks(data) {
+    var blocksLuckCount: number = 0;
+    data['results'].forEach(v => {
+      blocksLuckCount = blocksLuckCount + v['luck'];
+    });
+    this.blocksLuckAverage = blocksLuckCount / data['count'];
     this.blocksCollectionSize = data['count'];
     this._blocks$.next(data['results']);
   }


### PR DESCRIPTION
## Description

Add block luck average (blocks tab) in farmer page.

Average from the total blocks luck / total blocks.

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [ ] Mobile

## Screenshot(s)

<img width="1461" alt="image" src="https://user-images.githubusercontent.com/2886596/222243216-88efa1b3-889e-422f-a7a5-e70cf6cc2294.png">

## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
