### PR TITLE
feat: reduce api callback in farmer page, load if tab is selected

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -372,7 +372,7 @@
       </li>
 
       <!-- Harvesters -->
-      <li [ngbNavItem]="2">
+      <li [ngbNavItem]="2" (click)="getHarvesters(farmer.launcher_id)">
         <a ngbNavLink><i class="fa fa-tractor"></i>&nbsp;<span i18n="@@Harvesters">Harvesters</span></a>
         <ng-template ngbNavContent>
           <div *ngFor="let mapEntry of perHarvesterData | keyvalue">
@@ -445,7 +445,7 @@
       </li>
 
       <!-- Estimated Size -->
-      <li [ngbNavItem]="3">
+      <li [ngbNavItem]="3" (click)="getSize(farmer.launcher_id)">
         <a ngbNavLink><i class="fa fa-expand"></i>&nbsp;<span i18n>Estimated Size</span></a>
         <ng-template ngbNavContent>
           <div class="row justify-content-center">
@@ -465,7 +465,7 @@
       </li>
 
       <!-- Rewards -->
-      <li [ngbNavItem]="4">
+      <li [ngbNavItem]="4" (click)="getRewards(); refreshPayouts()">
         <a ngbNavLink><i class="fa-solid fa-coins"></i>&nbsp;<span i18n>Rewards</span></a>
         <ng-template ngbNavContent>
           <div class="row justify-content-center">
@@ -560,7 +560,7 @@
       </li>
 
       <!-- Payouts -->
-      <li [ngbNavItem]="5">
+      <li [ngbNavItem]="5" (click)="refreshPayoutTxs()">
         <a ngbNavLink><i class="fa fa-wallet"></i>&nbsp;<span i18n>Payouts</span></a>
         <ng-template ngbNavContent>
           <br />
@@ -653,7 +653,7 @@
       </li>
 
       <!-- Blocks -->
-      <li [ngbNavItem]="6">
+      <li [ngbNavItem]="6" (click)="refreshBlocks()">
         <a ngbNavLink><i class="fa fa-cube"></i>&nbsp;<span i18n>Blocks</span></a>
         <ng-template ngbNavContent>
           <br />

--- a/src/app/explorer/farmer/farmer.component.ts
+++ b/src/app/explorer/farmer/farmer.component.ts
@@ -104,15 +104,9 @@ export class FarmerComponent implements OnInit {
   ngOnInit(): void {
     this.route.paramMap.subscribe(data => {
       this.farmerid = data['params']['id'];
-      this.refreshBlocks();
-      this.refreshPayouts();
-      this.refreshPayoutTxs();
       this.dataService.getLauncher(this.farmerid).subscribe(launcher => {
         this.farmer = launcher;
         this.getPartialsData(this.farmerid);
-        this.getSize(this.farmerid);
-        this.getHarvesters(this.farmerid);
-        this.getRewards();
         this.dataService.getStats().subscribe(data => {
           this.xch_current_price_usd = data['xch_current_price']['usd'];
           this.xch_tb_month = data['xch_tb_month'];


### PR DESCRIPTION
## Description

Reduce API calls in farmer page, now only when tab is selected (click).

## Test(s)

Yes from localhost on each tab from zero

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [ ] Mobile

## Screenshot(s)

No screenshot (no visual changes)

## Issue(s)

Issue #234 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
