### PR TITLE
feat: add payouttxs chart in farmer page (payouts tab)

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -566,6 +566,28 @@
           <br />
           <div class="row justify-content-center">
             <div class="col-lg-12">
+              <div class="col-lg-12" style="display: block;" #payoutsTxsChartContainerRef>
+                <ngx-charts-area-chart [view]="[payoutsTxsChartContainerRef.offsetWidth, 280]"
+                  [legend]="payoutsTxsChartLegend" [legendTitle]="payoutsTxsChartLegendTitle"
+                  [gradient]="payoutsTxsChartGradient" [scheme]="payoutsTxsChartColors"
+                  [showXAxisLabel]="payoutsTxsChartAxisXLabel" [showYAxisLabel]="payoutsTxsChartAxisYLabel"
+                  [xAxisLabel]="payoutsTxsChartAxisXLabel" [yAxisLabel]="payoutsTxsChartAxisYLabel"
+                  [xAxis]="payoutsTxsChartAxisX" [yAxis]="payoutsTxsChartAxisY"
+                  [timeline]="payoutsTxsChartShowTimeline" [yAxisTickFormatting]="payoutsTxsChartFormatAxisY"
+                  [results]="payoutsTxsChartData">
+                  <ng-template #seriesTooltipTemplate let-model="model">
+                    {{ model[0].label }}<br />
+                    {{ model[0].name }}
+                  </ng-template>
+                  <ng-template #tooltipTemplate let-model="model">
+                    {{ model[0].label }}<br />
+                    {{ model[0].name }}
+                  </ng-template>
+                </ngx-charts-area-chart>
+              </div>
+              <br />
+            </div>
+            <div class="col-lg-12">
               <div class="row row-grid">
                 <div class="col-lg-3 justify-content-center">
                   <div class="card card-lift shadow border-0">

--- a/src/app/explorer/farmer/farmer.component.ts
+++ b/src/app/explorer/farmer/farmer.component.ts
@@ -74,6 +74,18 @@ export class FarmerComponent implements OnInit {
   payouttxsCountTotal: number = 0;
   payouttxsAmountTotal: number = 0;
 
+  payoutsTxsChartLegend: boolean = false;
+  payoutsTxsChartLegendTitle: string = '';
+  payoutsTxsChartAnimations: boolean = true;
+  payoutsTxsChartGradient: boolean = true;
+  payoutsTxsChartShowTimeline: boolean = false;
+  payoutsTxsChartAxisX: boolean = false;
+  payoutsTxsChartAxisY: boolean = true;
+  payoutsTxsChartShowAxisXLabel: boolean = false;
+  payoutsTxsChartShowAxisYLabel: boolean = true;
+  payoutsTxsChartAxisYLabel: string = $localize`Payouts (XCH)`;
+  payoutsTxsChartData: any[] = null;
+
   blocks$: Observable<any[]>;
   _blocks$ = new BehaviorSubject<any[]>([]);
   blocksCollectionSize: number = 0;
@@ -86,6 +98,7 @@ export class FarmerComponent implements OnInit {
 
   partialsChartColors = { domain: ['#129b00', '#e00000'] };
   sizeChartColors = { domain: ['#006400', '#9ef01a'] };
+  payoutsTxsChartColors = { domain: ['#129b00', '#e00000'] };
 
   private farmerid: string;
   public farmer: any = {};
@@ -213,6 +226,16 @@ export class FarmerComponent implements OnInit {
   }
 
   private handlePayoutTxs(data) {
+    this.payoutsTxsChartData = [{
+      "name": "Payouts",
+      "series": (<any[]>data['results']).reverse().map((item) => {
+        return ({
+          "name": (item['created_at_time'] || 0).toLocaleString(),
+          "value": (item['amount'] / 10 ** 12),
+          "label": (item['amount'] / 10 ** 12).toString() + ' XCH',
+        })
+      })
+    }];
     this.payouttxsCollectionSize = data['count'];
     this._payouttxs$.next(data['results']);
   }
@@ -366,9 +389,12 @@ export class FarmerComponent implements OnInit {
     return (data / 10 ** 12).toFixed(2).toString() + ' XCH';
   }
 
-
   partialsXAxisFormat(data) {
     return new Date(data * 1000).toLocaleTimeString();
+  }
+
+  payoutsTxsChartFormatAxisY(data: number) {
+    return (data).toFixed(6).toString() + ' XCH';
   }
 
   showPartialError(content) {


### PR DESCRIPTION
## Description

Add payouttxs chart (payouts tab) in the farmer page. Works with pagination.

> Need more tests for my part.

## Test(s)

Yes from localhost, with big/small farmer (payouts)

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [ ] Mobile

## Screenshot(s)

<img width="1458" alt="image" src="https://user-images.githubusercontent.com/2886596/222270116-9eb5a5fd-155f-4711-b900-9b4044de355d.png">

## Issue(s)

Issue #347 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
