### PR TITLE
misc: improve github details in footer

### DIFF
--- a/angular-git-version.js
+++ b/angular-git-version.js
@@ -1,6 +1,12 @@
 const git = require('git-rev-sync');
 const { writeFileSync } = require('fs');
-const gitInfo = { commitShort: git.short(), commitLong: git.long(), branchName: git.branch() };
+const gitInfo = {
+    commitShort: git.short(),
+    commitLong: git.long(),
+    branchName: git.branch(),
+    tagName: git.tag(),
+    date: git.date()
+};
 const ts = 'export const gitVersion = ' + JSON.stringify(gitInfo, null, 2);
 
 writeFileSync('./src/environments/git-version.ts', ts);

--- a/src/app/shared/footer/footer.component.html
+++ b/src/app/shared/footer/footer.component.html
@@ -45,7 +45,7 @@
               <div class="col-lg-12 text-center">
                 <i class="fa-solid fa-bug"></i>&nbsp;
                 <span i18n>You found a bug, or propose a feature? Open an issue on</span>&nbsp;
-                <a target="_blank" href="https://github.com">Github</a>.
+                <a target="_blank" href="https://github.com/openchia/web/issues/new">Github</a>.
                 <table class="table table-sm table-striped table-responsive-lg text-left">
                   <br />
                   <tbody>

--- a/src/app/shared/footer/footer.component.html
+++ b/src/app/shared/footer/footer.component.html
@@ -42,15 +42,50 @@
               </button>
             </div>
             <div class="modal-body">
-              <div class="col-lg-12 text-left">
-                <i class="fa-solid fa-code-branch"></i>&nbsp;&nbsp;
-                <b i18n="">Branch</b>: <a target="_blank"
-                  href="https://github.com/openchia/web/tree/{{ gitVersion.branchName }}">
-                  {{ gitVersion.branchName }}</a><br />
-                <i class="fa-solid fa-code-commit"></i>&nbsp;
-                <b i18n="">Commit</b>: <a target="_blank"
-                  href="https://github.com/openchia/web/commit/{{ gitVersion.commitLong }}">
-                  {{ gitVersion.commitLong }}</a>
+              <div class="col-lg-12 text-center">
+                <i class="fa-solid fa-bug"></i>&nbsp;
+                <span i18n>You found a bug, or propose a feature? Open an issue on</span>&nbsp;
+                <a target="_blank" href="https://github.com">Github</a>.
+                <table class="table table-sm table-striped table-responsive-lg text-left">
+                  <br />
+                  <tbody>
+                    <tr *ngIf="gitVersion.tag == gitVersion.commit">
+                      <th scope="col"><i class="fa-solid fa-code-branch"></i></th>
+                      <td><b><span i18n>Branch</span></b></td>
+                      <td>
+                        <a target="_blank"
+                          href="https://github.com/openchia/web/tree/{{ gitVersion.branchName }}">
+                          {{ gitVersion.branchName }}
+                        </a>
+                      </td>
+                    </tr>
+                    <tr *ngIf="gitVersion.tag != gitVersion.commit">
+                      <th scope="col"><i class="fa-solid fa-code-merge"></i></th>
+                      <td><b><span i18n>Release</span></b></td>
+                      <td>
+                        <a target="_blank"
+                          href="https://github.com/openchia/web/releases/tag/{{ gitVersion.tagName }}">
+                          {{ gitVersion.tagName }}
+                        </a>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="col"><i class="fa-solid fa-code-commit"></i></th>
+                      <td><b><span i18n>Commit</span></b></td>
+                      <td>
+                        <a target="_blank"
+                          href="https://github.com/openchia/web/commit/{{ gitVersion.commitLong }}">
+                          {{ gitVersion.commitLong }}
+                        </a>
+                      </td>
+                    </tr>
+                    <tr>
+                      <th scope="col"><i class="fa-solid fa-clock"></i></th>
+                      <td><b><span i18n>Date</span></b></td>
+                      <td>{{ gitVersion.date | date:'long' }}</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
             <div class="modal-footer">

--- a/src/app/shared/footer/footer.component.scss
+++ b/src/app/shared/footer/footer.component.scss
@@ -1,0 +1,5 @@
+.git-logo {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}


### PR DESCRIPTION
## Description

Improve Github details in footer:
* Quick line to open an issue
* Details in table
* Date added
* Show tag if set, else it's the branch name

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [ ] Mobile

## Screenshot(s)

Small changes

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/2886596/222530109-8688ed7f-03d7-4bd3-bec1-4c317e44d444.png">

## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
