### PR TITLE
fix: reverse payouttxs in farmer page

### DIFF
--- a/src/app/explorer/farmer/farmer.component.ts
+++ b/src/app/explorer/farmer/farmer.component.ts
@@ -237,7 +237,7 @@ export class FarmerComponent implements OnInit {
       })
     }];
     this.payouttxsCollectionSize = data['count'];
-    this._payouttxs$.next(data['results']);
+    this._payouttxs$.next(data['results'].reverse());
   }
 
   refreshPayoutTxs() {


### PR DESCRIPTION
## Description

Fix payouttxs order (table) in farmer page

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [x] Mobile

## Screenshot(s)

No screenshot

## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

