### PR TITLE
fix(farmer): settings qrcode background (darkmode)

### DIFF
--- a/src/app/explorer/login/login.component.css
+++ b/src/app/explorer/login/login.component.css
@@ -14,3 +14,8 @@
   margin-top: 0.25rem;
   margin-left: 1rem;
 }
+
+.qrcode-bg {
+  background-color: #ffffff;
+  border-radius: 10px;
+}

--- a/src/app/explorer/login/login.component.html
+++ b/src/app/explorer/login/login.component.html
@@ -188,7 +188,7 @@
                 </div>
               </div>
               <div class="col-lg-2 col-sm-2 text-center">
-                <svg width="220" height="220">
+                <svg class="qrcode-bg" width="220" height="220">
                   <image xlink:href="/api/v1.0/qrcode" src="qrcode.png" width="220" height="220" />
                 </svg>
                 <p><span i18n>Mobile Login</span></p>


### PR DESCRIPTION
## Description

Add qrcode background (better view in darkmode)

## Test(s)

No only live tests

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [x] Mobile

## Screenshot(s)

![image](https://user-images.githubusercontent.com/2886596/222961983-1f6465d6-2f08-49bf-bfab-fa8a4b7d270b.png)

## Issue(s)

Issue #357 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
