### PR TITLE
fix: bottom white line in darkmode

### DIFF
--- a/src/assets/scss/custom/toggle-bootstrap-dark.scss
+++ b/src/assets/scss/custom/toggle-bootstrap-dark.scss
@@ -49,6 +49,10 @@ body.bootstrap-dark {
     .badge-danger {
         background-color: #e74c3c;
     }
+
+    .accordion-1 .accordion .card {
+    	border-bottom: 1px solid #3d4044 !important;
+    }
 }
 
 .bootstrap-dark {


### PR DESCRIPTION
## Description

Fix bottom white line in darkmode

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [x] Mobile

## Screenshot(s)

Before:
<img width="1476" alt="image" src="https://user-images.githubusercontent.com/2886596/223233837-f1012f98-2469-42c6-a3ef-9e2388655269.png">

After:
<img width="1462" alt="image" src="https://user-images.githubusercontent.com/2886596/223233888-da62dd1c-7972-4024-a7fd-8bab086237b9.png">


## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
