### PR TITLE
feat(farmer): move from line-area to bar chart for payouttxs

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -567,23 +567,17 @@
           <div class="row justify-content-center">
             <div class="col-lg-12">
               <div class="col-lg-12" style="display: block;" #payoutsTxsChartContainerRef>
-                <ngx-charts-area-chart [view]="[payoutsTxsChartContainerRef.offsetWidth, 280]"
+                <ngx-charts-bar-vertical [view]="[payoutsTxsChartContainerRef.offsetWidth, 280]"
                   [legend]="payoutsTxsChartLegend" [legendTitle]="payoutsTxsChartLegendTitle"
                   [gradient]="payoutsTxsChartGradient" [scheme]="payoutsTxsChartColors"
                   [showXAxisLabel]="payoutsTxsChartAxisXLabel" [showYAxisLabel]="payoutsTxsChartAxisYLabel"
-                  [xAxisLabel]="payoutsTxsChartAxisXLabel" [yAxisLabel]="payoutsTxsChartAxisYLabel"
+                  [yAxisLabel]="payoutsTxsChartAxisYLabel" [yAxisTickFormatting]="payoutsTxsChartFormatAxisY"
                   [xAxis]="payoutsTxsChartAxisX" [yAxis]="payoutsTxsChartAxisY"
-                  [timeline]="payoutsTxsChartShowTimeline" [yAxisTickFormatting]="payoutsTxsChartFormatAxisY"
-                  [results]="payoutsTxsChartData">
-                  <ng-template #seriesTooltipTemplate let-model="model">
-                    {{ model[0].label }}<br />
-                    {{ model[0].name }}
-                  </ng-template>
+                  [results]="payoutsTxsChartData" [roundEdges]="false" [noBarWhenZero]="false">
                   <ng-template #tooltipTemplate let-model="model">
-                    {{ model[0].label }}<br />
-                    {{ model[0].name }}
+                    {{ model.name }}<br />{{ model.value }}XCH
                   </ng-template>
-                </ngx-charts-area-chart>
+                </ngx-charts-bar-vertical>
               </div>
               <br />
             </div>

--- a/src/app/explorer/farmer/farmer.component.ts
+++ b/src/app/explorer/farmer/farmer.component.ts
@@ -99,7 +99,7 @@ export class FarmerComponent implements OnInit {
 
   partialsChartColors = { domain: ['#129b00', '#e00000'] };
   sizeChartColors = { domain: ['#006400', '#9ef01a'] };
-  payoutsTxsChartColors = { domain: ['#129b00', '#e00000'] };
+  payoutsTxsChartColors = { domain: ['#129b00'] };
 
   private farmerid: string;
   public farmer: any = {};
@@ -226,16 +226,15 @@ export class FarmerComponent implements OnInit {
   }
 
   private handlePayoutTxs(data) {
-    this.payoutsTxsChartData = [{
-      "name": "Payouts",
-      "series": (<any[]>data['results']).reverse().map((item) => {
-        return ({
-          "name": (item['created_at_time'] || 0).toLocaleString(),
-          "value": (item['amount'] / 10 ** 12),
-          "label": (item['amount'] / 10 ** 12).toString() + ' XCH',
-        })
+    var seriesPayoutsTxsChart = [];
+    (<any[]>data['results']).reverse().map((i) => {
+      seriesPayoutsTxsChart.push({
+        "name": (i['created_at_time'] || $localize`Unpaid`).toLocaleString(),
+        "value": (i['amount'] / 10 ** 12),
+        "label": (i['amount'] / 10 ** 12).toString() + ' XCH'
       })
-    }];
+    });
+    this.payoutsTxsChartData = seriesPayoutsTxsChart;
     this.payouttxsCollectionSize = data['count'];
     this._payouttxs$.next(data['results'].reverse());
   }


### PR DESCRIPTION
## Description

Improve payouttxs chart in farmer page:
* From line-area to bar chart (better view)
* Show unpaid payouttxs

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [x] Mobile

## Screenshot(s)

<img width="1519" alt="image" src="https://user-images.githubusercontent.com/2886596/223863798-d13bc0e9-6c61-4d67-98fa-a4f73671ef25.png">

## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
