### PR TITLE
fix: show farmer blocks details only if a blocks has been won

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -675,7 +675,7 @@
         <ng-template ngbNavContent>
           <br />
           <div class="row justify-content-center">
-            <div class="col-lg-12">
+            <div *ngIf="blocksEffortChartData != ''" class="col-lg-12">
               <div class="col-lg-12" style="display: block;" #blocksEffortChartContainerRef>
                 <ngx-charts-bar-vertical [view]="[blocksEffortChartContainerRef.offsetWidth, 280]"
                   [legend]="blocksEffortChartLegend" [legendTitle]="blocksEffortChartLegendTitle"
@@ -706,7 +706,8 @@
                   <div class="card card-lift shadow border-0">
                     <div *ngIf="blocks$ | async; let blocks" class="card-body py-3 text-center text-uppercase">
                       <span class="text-primary"><span i18n="@@EffortAverage">Effort Average</span></span>
-                      <p class="display-3">{{ blocksEffortAverage | number:'.0-1' }}%</p>
+                      <p *ngIf="blocksEffortAverage" class="display-3">{{ blocksEffortAverage | number:'.0-1' }}%</p>
+                      <p *ngIf="!blocksEffortAverage" class="display-3">-</p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Description

Show blocks details only if a block has been won

## Test(s)

Yes from localhost with a big and small farmers

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [x] Mobile

## Screenshot(s)

Before:

![image](https://user-images.githubusercontent.com/2886596/224257501-a7f9e485-4836-4cea-b883-5358d8ea5836.png)

After:

![image](https://user-images.githubusercontent.com/2886596/224257568-a32ca01f-a3a0-41f4-8687-c6bbedb610d7.png)

## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
