### PR TITLE
fix(farmer): improve badge text color and effort

### DIFF
--- a/src/app/explorer/farmer/farmer.component.ts
+++ b/src/app/explorer/farmer/farmer.component.ts
@@ -205,7 +205,9 @@ export class FarmerComponent implements OnInit {
     var blocksEffortCount: number = 0;
     var seriesBlocksEffortChart = [];
     data['results'].forEach(v => {
-      blocksEffortCount = blocksEffortCount + v['launcher_effort'];
+      if(v['launcher_effort'] != -1) {
+        blocksEffortCount = blocksEffortCount + v['launcher_effort'];
+      }
     });
     (<any[]>data['results']).map((i) => {
       seriesBlocksEffortChart.push({

--- a/src/assets/scss/custom/toggle-bootstrap-dark.scss
+++ b/src/assets/scss/custom/toggle-bootstrap-dark.scss
@@ -50,6 +50,10 @@ body.bootstrap-dark {
         background-color: #e74c3c;
     }
 
+    .badge-secondary {
+        color: #d3d3d3;
+    }
+
     .accordion-1 .accordion .card {
     	border-bottom: 1px solid #3d4044 !important;
     }


### PR DESCRIPTION
## Description

Fix farmer blocks view:
* Secondary badge text color
* Block effort when no data (return `-` and not `-1%`)

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [ ] Mobile

## Screenshot(s)

<img width="1426" alt="image" src="https://user-images.githubusercontent.com/2886596/225750614-140d3f74-3a4b-4f1f-939b-60c1e9787fe8.png">

## Issue(s)

Issue #387 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
