### PR TITLE
fix(farmer): estimated size chart values

### DIFF
--- a/src/app/explorer/farmer/farmer.component.ts
+++ b/src/app/explorer/farmer/farmer.component.ts
@@ -382,7 +382,7 @@ export class FarmerComponent implements OnInit {
         }
         where['series'].push({
           'name': new Date(i['datetime']).toLocaleString(),
-          'value': i['value'],
+          'value': i['value'] / 1024 ** 4,
           'label': where['name'] + ': ' + (i['value'] / 1024 ** 4).toFixed(2).toString() + ' TiB',
         })
       });
@@ -390,8 +390,8 @@ export class FarmerComponent implements OnInit {
     });
   }
 
-  spaceFormatAxisY(spaceData: number) {
-    return (spaceData / 1024 ** 4).toFixed(2).toString() + ' TiB';
+  spaceFormatAxisY(data: number) {
+    return (data).toFixed(2).toString() + ' TiB';
   }
 
   rewardsFormatAxisY(data: number) {


### PR DESCRIPTION
## Description

Improve view of estimated size (farmer page)

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [ ] Mobile

## Screenshot(s)

Before:

<img width="527" alt="image" src="https://user-images.githubusercontent.com/2886596/226171480-a54eabe8-7c13-479a-bf89-efbade437d7f.png">

After:

<img width="445" alt="image" src="https://user-images.githubusercontent.com/2886596/226171502-ab128f7b-7bd5-4383-b6c5-baa678cb8983.png">

## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
