### PR TITLE
fix(cli): npm run start warning

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -55,7 +55,12 @@
             "tsConfig": "src/tsconfig.app.json",
             "allowedCommonJsDependencies": [
               "rxjs/add/operator/filter",
-              "ng2-nouislider"
+              "ng2-nouislider",
+              "rfdc",
+              "xterm",
+              "xterm-addon-fit",
+              "filesize",
+              "angular-csv-ext/dist/Angular-csv"
             ],
             "assets": [
               "src/favicon.ico",

--- a/src/assets/scss/custom/toggle-bootstrap-dark.scss
+++ b/src/assets/scss/custom/toggle-bootstrap-dark.scss
@@ -60,6 +60,8 @@ body.bootstrap-dark {
 }
 
 .bootstrap-dark {
+    $custom-file-text: ();
+
     @import "bootstrap/scss/functions";
     @import "functions";
 

--- a/src/assets/scss/custom/toggle-bootstrap.scss
+++ b/src/assets/scss/custom/toggle-bootstrap.scss
@@ -19,6 +19,8 @@ body.bootstrap {
 }
 
 .bootstrap {
+    $custom-file-text: ();
+
     @import "bootstrap/scss/functions";
     @import "functions";
 


### PR DESCRIPTION
## Description

Warnings fixes during `npm run start` command:
* 5 warnings related to dependencies (`CommonJS or AMD dependencies can cause optimization bailouts`)
* 2 warnings related to bootstrap pseudo class lang

## Test(s)

Yes from localhost

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [ ] Mobile

## Screenshot(s)

No screenshot

## Issue(s)

No issue

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
