### PR TITLE
fix(farmer): blocks effort average

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -709,7 +709,13 @@
                 <div class="col-lg-6 justify-content-center">
                   <div class="card card-lift shadow border-0">
                     <div *ngIf="blocks$ | async; let blocks" class="card-body py-3 text-center text-uppercase">
-                      <span class="text-primary"><span i18n="@@EffortAverage">Effort Average</span></span>
+                      <span class="text-primary">
+                        <ng-template #blocksEffortAverageTooltip>
+                          <span i18n>Calculated from effort of your {{ blocksPageSize }} blocks in the list.</span>
+                        </ng-template>
+                        <span i18n="@@EffortAverage">Effort Average</span>
+                        &nbsp;<i class="fas fa-info-circle" closeDelay="4000" [ngbTooltip]="blocksEffortAverageTooltip"></i>
+                      </span>
                       <p *ngIf="blocksEffortAverage" class="display-3">{{ blocksEffortAverage | number:'.0-1' }}%</p>
                       <p *ngIf="!blocksEffortAverage" class="display-3">-</p>
                     </div>

--- a/src/app/explorer/farmer/farmer.component.ts
+++ b/src/app/explorer/farmer/farmer.component.ts
@@ -216,7 +216,7 @@ export class FarmerComponent implements OnInit {
         "label": $localize`Effort ${i['launcher_effort']}`
       })
     });
-    this.blocksEffortAverage = blocksEffortCount / data['count'];
+    this.blocksEffortAverage = blocksEffortCount / this.blocksPageSize;
     this.blocksEffortChartData = seriesBlocksEffortChart.reverse();
     this.blocksCollectionSize = data['count'];
     this._blocks$.next(data['results']);


### PR DESCRIPTION
## Description

Fix the farmer effort average method of calcul. Not based from all blocks (require a new call without limit).
So now effort average is based on blocks in the list (works with pagination).

## Test(s)

From localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [ ] Mobile

## Screenshot(s)

No screenshot.

## Issue(s)

No issue opened. This bug has been reported on Discord.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
