### PR TITLE
feat: add blocks csv export

### DIFF
--- a/src/app/explorer/farmer/farmer.component.html
+++ b/src/app/explorer/farmer/farmer.component.html
@@ -698,7 +698,7 @@
             </div>
             <div class="col-lg-12">
               <div class="row row-grid">
-                <div class="col-lg-6 justify-content-center">
+                <div class="col-lg-4 justify-content-center">
                   <div class="card card-lift shadow border-0">
                     <div *ngIf="blocks$ | async; let blocks" class="card-body py-3 text-center text-uppercase">
                       <span class="text-primary"><span i18n="">Total block(s)</span></span>
@@ -706,7 +706,7 @@
                     </div>
                   </div>
                 </div>
-                <div class="col-lg-6 justify-content-center">
+                <div class="col-lg-4 justify-content-center">
                   <div class="card card-lift shadow border-0">
                     <div *ngIf="blocks$ | async; let blocks" class="card-body py-3 text-center text-uppercase">
                       <span class="text-primary">
@@ -720,6 +720,25 @@
                       </span>
                       <p *ngIf="blocksEffortAverage" class="display-3">{{ blocksEffortAverage | number:'.0-1' }}%</p>
                       <p *ngIf="!blocksEffortAverage" class="display-3">-</p>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-lg-4 justify-content-center">
+                  <div class="card card-lift shadow border-0">
+                    <div *ngIf="(blocks$ | async) as blocks" class="card-body py-3 text-center text-uppercase">
+                      <span class="text-primary">
+                        <i class="fa-solid fa-download"></i>&nbsp;
+                        <span i18n="">Export CSV</span>
+                      </span>
+                      <p class="display-4">
+                        <button *ngIf="blocks.length>=1" class="btn btn-primary btn-icon"
+                          (click)="blocksDownloadCSV()">
+                          <i class="fa-solid"><span i18n="">Download</span></i>
+                        </button>
+                        <button *ngIf="blocks.length==0" disabled class="btn btn-primary btn-icon disabled">
+                          <i class="fa-solid"><span i18n="">No blocks found</span></i>
+                        </button>
+                      </p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Description

Allow to export the list of blocks (farmer) in CSV format

## Test(s)

From localhost

And through the environments (browser):

- [x] Desktop
- [ ] Tablet
- [ ] Mobile

## Screenshot(s)

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/2886596/228347854-d6dfade7-d702-4267-88e0-ae27f98bf9ca.png">

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/2886596/228347953-de3047f0-75df-44ea-8035-4a56b56f6aaf.png">

<img width="1298" alt="image" src="https://user-images.githubusercontent.com/2886596/228348144-b3473eeb-f961-43c4-bd2e-314b5183e9b8.png">

> Empty case when xch price is not defined
> Effort -1 when is not defined

## Issue(s)

Issue #416 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
