### PR TITLE
feat: remove openchia twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@
   <a style="text-decoration:none" href="https://discord.gg/2URS9H7RZn">
     <img alt="Discord" src="https://img.shields.io/discord/865233670938689537?logo=discord&color=0&logoColor=white&label=Discord&style=flat-square">
   </a>
-  <a style="text-decoration:none" href="https://twitter.com/openchia">
-    <img alt="Twitter" src="https://img.shields.io/badge/follow-%40openchia-1DA1F2?color=blue&label=Twitter&logo=twitter&logoColor=white&style=flat-square">
-  </a>
   <a style="text-decoration:none" href="https://www.youtube.com/channel/UCL70j_KiPd49rfp_UEqxiyQ">
     <img alt="YouTube" src="https://img.shields.io/youtube/channel/subscribers/UCL70j_KiPd49rfp_UEqxiyQ?label=YouTube&logo=youtube&logoColor=white&style=flat-square">
   </a>

--- a/src/app/giveaway/giveaway.component.html
+++ b/src/app/giveaway/giveaway.component.html
@@ -20,7 +20,7 @@
     <p i18n>First of all, we have noticed little to no engagement from our community in regards to that. We often found
       ourselves doing the livestream to draw the winner number and we did not have anybody watching and the number of
       views afterwards were also very slim.</p>
-    <p i18n>A poll was made in our Discord and Twitter regarding the giveaway versus discount fees for all farmers. It
+    <p i18n>A poll was made in our Discord regarding the giveaway versus discount fees for all farmers. It
       turns out people preferred discount fees and that is what we implemented and pushed live before ending the
       giveaway.</p>
     <p i18n>Finally, the giveaway is no longer creating the interest and return that we were hoping for and given

--- a/src/app/landing/landing.component.html
+++ b/src/app/landing/landing.component.html
@@ -157,17 +157,15 @@
               <div class="row justify-content-center">
                 <div class="col-md-6">
                   <div class="card-pricing card-landing-join bg-white border-0 text-center mb-4 card">
-                    <a class="twitter-timeline" data-height="400"
-                      href="https://twitter.com/OpenChia?ref_src=twsrc%5Etfw" i18n>
-                      Tweets by OpenChia
-                    </a>
+                    <iframe [src]="discord_widget_url" width="400" height="400" frameborder="0" allowtransparency="true"
+                      sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts">
+                    </iframe>
                   </div>
                 </div>
                 <div class="col-md-6">
                   <div class="card-pricing card-landing-join bg-white border-0 text-center mb-4 card">
-                    <a class="twitter-timeline" data-height="400"
-                      href="https://twitter.com/chia_project?ref_src=twsrc%5Etfw" i18n>
-                      Tweets by OpenChia
+                    <a [href]="twitter_widget_url" class="twitter-timeline" data-height="400" i18n>
+                      Tweets by @chia_project
                     </a>
                   </div>
                 </div>

--- a/src/app/landing/landing.component.ts
+++ b/src/app/landing/landing.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { DataService } from '../data.service';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
     selector: 'app-landing',
@@ -15,8 +16,15 @@ export class LandingComponent implements OnInit {
   farmers: any;
   rewards_blocks: any;
   xch_tb_month: number = 0;
+  discord_widget_url: any;
+  discord_widget_id: string = "865233670938689537"
+  twitter_widget_url: any;
+  twitter_widget_user: string = "chia_project";
 
-  constructor(private dataService: DataService) { }
+  constructor(
+    private dataService: DataService,
+    private sanitizer: DomSanitizer
+  ) { }
 
   ngOnInit() {
     this.dataService.getStats().subscribe(data => {
@@ -26,7 +34,26 @@ export class LandingComponent implements OnInit {
       this.farmers = data['farmers_active'];
       this.rewards_blocks = data['rewards_blocks'];
       this.xch_tb_month = data['xch_tb_month'];
-    })
+    });
+    this.discord_widget_url = this.discord_widget(this.discord_widget_id);
+    this.twitter_widget_url = this.twitter_widget(this.twitter_widget_user);
+  }
+
+  getTheme() {
+    return (localStorage.getItem("darkmode") == "true") ? "dark" : "light"
+  }
+
+  discord_widget(id: string) {
+    return this.sanitizer.bypassSecurityTrustResourceUrl(
+      "https://discord.com/widget?id=" + id + "&theme=" + this.getTheme()
+    );
+  }
+
+  twitter_widget(user: string) {
+    var theme = this.getTheme() == "dark" ? "&theme=dark" : "";
+    return this.sanitizer.bypassSecurityTrustResourceUrl(
+      "https://twitter.com/" + user + "?ref_src=twsrc%5Etfw" + theme
+    );
   }
 
   private secondsToHm(d: number) {

--- a/src/app/shared/footer/footer.component.html
+++ b/src/app/shared/footer/footer.component.html
@@ -18,10 +18,6 @@
           class="btn btn-neutral btn-icon-only btn-github btn-round btn-lg" ngbTooltip="Star on Github">
           <i class="fab fa-github"></i>
         </a>
-        <a target="_blank" href="https://twitter.com/openchia"
-          class="btn btn-neutral btn-icon-only btn-twitter btn-round btn-lg" ngbTooltip="Follow on Twitter">
-          <i class="fab fa-twitter"></i>
-        </a>
       </div>
     </div>
     <hr>

--- a/src/app/shared/navbar/navbar.component.html
+++ b/src/app/shared/navbar/navbar.component.html
@@ -100,13 +100,6 @@
             <span class="nav-link-inner--text d-lg-none">Github</span>
           </a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link nav-link-icon" href="https://twitter.com/openchia" target="_blank" data-toggle="tooltip"
-            title="Follow on Twitter">
-            <i class="fab fa-twitter"></i>
-            <span class="nav-link-inner--text d-lg-none">Twitter</span>
-          </a>
-        </li>
         <li class="nav-item d-none d-lg-block ml-lg-4">
           <a class="btn btn-neutral btn-icon" [routerLink]="['/join']">
             <span class="nav-link-inner--text" i18n="@@JoinPool">Join our pool</span>

--- a/src/assets/scss/custom/_buttons.scss
+++ b/src/assets/scss/custom/_buttons.scss
@@ -70,8 +70,8 @@
 
 .btn-discord {
     color: #fff;
-    background: #747df7;
-    border-color: #747df7;
+    background: #5865f2;
+    border-color: #5865f2;
 }
 
 .btn-linkedin {

--- a/src/locale/en.xlf
+++ b/src/locale/en.xlf
@@ -2161,7 +2161,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="4ae21b04547f3b306d71c4691b63f96017e32fcf" datatype="html">
-        <source>A poll was made in our Discord and Twitter regarding the giveaway versus discount fees for all farmers. It turns out people preferred discount fees and that is what we implemented and pushed live before ending the giveaway.</source>
+        <source>A poll was made in our Discord regarding the giveaway versus discount fees for all farmers. It turns out people preferred discount fees and that is what we implemented and pushed live before ending the giveaway.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/giveaway/giveaway.component.html</context>
           <context context-type="linenumber">23,27</context>


### PR DESCRIPTION
## Description

* Remove OpenChia Twitter widget
* Replaced by Discord widget
* Improve Discord button color (aligned with the widget)
* Call widget in good mode (dark/light)

## Test(s)

From localhost

And through the environments (browser):

- [x] Desktop
- [x] Tablet
- [ ] Mobile

## Screenshot(s)

Dark mode:

![image](https://github.com/openchia/web/assets/2886596/0d555924-f66f-46e2-95c3-14585b615333)

Light mode:

![image](https://github.com/openchia/web/assets/2886596/9e2a8deb-aa07-4d7e-9c4b-485f0a910ef0)

## Issue(s)

Issue #429 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
